### PR TITLE
add offered_qos_profiles

### DIFF
--- a/iv_to_auto_bag_converter/converter.py
+++ b/iv_to_auto_bag_converter/converter.py
@@ -182,6 +182,7 @@ class AutoBagConverter:
                     name=self.__convert_dict[topic_type.name][0],
                     type=self.__convert_dict[topic_type.name][1],
                     serialization_format="cdr",
+                    offered_qos_profiles=topic_type.offered_qos_profiles,
                 )
             writer.create_topic(topic_type)
 


### PR DESCRIPTION
**Problem**
QoS information was missing in the converted metadata.yaml.

**Solution**
Added `offered_qos_profiles` to TopicMetaData.

**Check status**
I evaluated using rosbag. The evaluation is complete.

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>